### PR TITLE
Add Terraform for Jenkins components

### DIFF
--- a/terraform/aws/jenkins/jenkins-agent.tf
+++ b/terraform/aws/jenkins/jenkins-agent.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "jenkins-agent" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = "t2.medium"
+  associate_public_ip_address = true
+  subnet_id                   = aws_subnet.subnet.id
+  vpc_security_group_ids      = [aws_security_group.ingress-ssh-from-all.id]
+
+  key_name = "jenkins-server-key"
+}

--- a/terraform/aws/jenkins/jenkins-server.tf
+++ b/terraform/aws/jenkins/jenkins-server.tf
@@ -1,0 +1,23 @@
+resource "aws_instance" "jenkins-server" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = "t2.medium"
+  associate_public_ip_address = true
+  subnet_id                   = aws_subnet.subnet.id
+  vpc_security_group_ids      = [aws_security_group.ingress-ssh-from-all.id]
+
+  key_name   = "jenkins-server-key"
+}
+
+resource "aws_alb" "jenkins_alb" {
+  name            = "jenkins-alb"
+  subnets         = [aws_subnet.subnet.id]
+  security_groups = [aws_security_group.ingress-ssh-from-all.id]
+  internal        = true
+}
+
+resource "aws_alb_listener" "jenkins_alb_listener" {
+  load_balancer_arn = aws_alb.jenkins_alb.arn
+  port              = 8080
+  protocol          = "HTTP"
+  }
+}

--- a/terraform/aws/jenkins/vpc.tf
+++ b/terraform/aws/jenkins/vpc.tf
@@ -4,3 +4,38 @@ resource "aws_vpc" "vpc" {
     Name = "jenkins_vpc"
   }
 }
+resource "aws_subnet" "subnet" {
+  vpc_id                  = aws_vpc.vpc.id
+  cidr_block              = var.subnet
+  availability_zone       = "${var.AWS_REGION}a"
+  map_public_ip_on_launch = "true"
+  tags = {
+    Name = "jenkins_subnet"
+  }
+}
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.vpc.id
+  tags = {
+    Name = "jenkins_igw"
+  }
+}
+resource "aws_security_group" "ingress-ssh-from-all" {
+  name   = "jenkins-allow-all-ssh-sg"
+  vpc_id = aws_vpc.vpc.id
+
+  ingress {
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}


### PR DESCRIPTION
### Description

This adds Terraform code to support a jenkins server and agent. I also added VPC code to create subnets and security groups. The jenkins server should be able to be used for our production code base. Much better than our manual release process today!

### Tests Ran

Jenkins server and agent stand up in the lab. Everything should be good to go for us to run this in the production environment. I love terraform!
